### PR TITLE
Update README to use cdn.rawgit.com not GH pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ A release is published to the [GitHub Project Page](https://mitcdh.github.io/ui-
 
 1. Add a Machine Driver in Rancher (Admin tab -> Settings -> Machine Drivers)
   * Download URL: The URL for the `linux_amd64.tar.gz` driver binary from [https://github.com/scaleway/docker-machine-driver-scaleway/releases](https://github.com/scaleway/docker-machine-driver-scaleway/releases)
-  * Custom UI URL: [component.js](https://mitcdh.github.io/ui-driver-scaleway/dist/component.js)
+  * Custom UI URL: [https://cdn.rawgit.com/mitcdh/ui-driver-scaleway/master/dist/component.js](https://cdn.rawgit.com/mitcdh/ui-driver-scaleway/master/dist/component.js)
 2. Wait for the driver to become "Active"
 3. In Rancher go to (Infrastructure -> Hosts -> Add Host) and the Scaleway driver and custom UI should show up.
 


### PR DESCRIPTION
Github has changed the default certificate for non-SNI specifying requests to not be a wildcard for github.io, changed the README.md to specify the rawgit cdn rather than GitHub pages link to component.js as rancher's apache http library doesn't support SNI.